### PR TITLE
Create releases from v*.*.* tags and update actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,11 +14,16 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    tags-ignore:
+      - "v*"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    tags-ignore:
+      - "v*"
   schedule:
     - cron: '24 19 * * 2'
+  workflow_call:
 
 jobs:
   analyze:
@@ -39,11 +44,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,73 +2,75 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - '**.md'
+      - "**.md"
+    tags-ignore:
+      - "v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - '**.md'
+      - "**.md"
+    tags-ignore:
+      - "v*"
+  workflow_call:
+
+env:
+  GO_VERSION: 1.19
+  BASE_DIRECTORY: ./reg-attendee-service
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        path: ./reg-attendee-service
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ env.BASE_DIRECTORY }}
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.19
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-    # START pact-1.88.84 has a syntax error
-    # curl -L https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -o ./install-pact.sh &&
-    # cat ./install-pact.sh &&
-    # chmod u+x ./install-pact.sh &&
-    # ./install-pact.sh &&
-    # rm ./install-pact.sh &&
-    # END pact-1.88.84 has a syntax error
+      - name: Set up pact-foundation/pact-ruby-standalone
+        run: >
+          curl -L https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -o ./install-pact.sh &&
+          cat ./install-pact.sh &&
+          chmod u+x ./install-pact.sh &&
+          ./install-pact.sh &&
+          rm ./install-pact.sh &&
+          ls -al ./pact/bin &&
+          echo "$(pwd)/pact/bin" >> $GITHUB_PATH
+        shell: bash
 
-    - name: Set up pact-foundation/pact-ruby-standalone
-      run: >
-        curl -L https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.88.83/pact-1.88.83-linux-x86_64.tar.gz -o pact-1.88.83-linux-x86_64.tar.gz &&
-        tar xzf pact-1.88.83-linux-x86_64.tar.gz &&
-        rm pact-1.88.83-linux-x86_64.tar.gz &&
-        ls -al ./pact/bin &&
-        echo "$(pwd)/pact/bin" >> $GITHUB_PATH
-      shell: bash
+      - name: Print pact CLI versions
+        run: |-
+          echo "PATH=$PATH
+          pact-broker: $(pact-broker version)
+          pact-message: $(pact-message version)
+          pact-mock-service: $(pact-mock-service version)
+          pact-provider-verifier: $(pact-provider-verifier version)
+          pact-stub-service: $(pact-stub-service version)"
+        shell: bash
 
-    - name: Print pact CLI versions
-      run: |-
-        echo "PATH=$PATH
-        pact-broker: $(pact-broker version)
-        pact-message: $(pact-message version)
-        pact-mock-service: $(pact-mock-service version)
-        pact-provider-verifier: $(pact-provider-verifier version)
-        pact-stub-service: $(pact-stub-service version)"
-      shell: bash
+      - name: Build
+        run: go build -v ./...
+        working-directory: ${{ env.BASE_DIRECTORY }}
 
-    - name: Build
-      run: go build -v ./...
-      working-directory: ./reg-attendee-service
+      - name: Checkout eurofurence/reg-attendee-transferclient for contract tests
+        uses: actions/checkout@v3
+        with:
+          repository: eurofurence/reg-attendee-transferclient
+          path: reg-attendee-transferclient
 
-    - name: Checkout eurofurence/reg-attendee-transferclient for contract tests
-      uses: actions/checkout@v2
-      with:
-        repository: eurofurence/reg-attendee-transferclient
-        path: reg-attendee-transferclient
+      - name: Build eurofurence/reg-attendee-transferclient
+        run: go build -v ./...
+        working-directory: ./reg-attendee-transferclient
 
-    - name: Build eurofurence/reg-attendee-transferclient
-      run: go build -v ./...
-      working-directory: ./reg-attendee-transferclient
+      - name: Test eurofurence/reg-attendee-transferclient
+        run: go test -v ./...
+        working-directory: ./reg-attendee-transferclient
 
-    - name: Test eurofurence/reg-attendee-transferclient
-      run: go test -v ./...
-      working-directory: ./reg-attendee-transferclient
-
-    - name: Test
-      run: go test -v ./...
-      working-directory: ./reg-attendee-service
+      - name: Test
+        run: go test -v ./...
+        working-directory: ${{ env.BASE_DIRECTORY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  GO_VERSION: 1.19
+  SERVICE_NAME: reg-attendee-service
+
+jobs:
+  # call_build_and_test:
+  #   uses: ./.github/workflows/go.yml
+
+  # call_codeql_analysis:
+  #   uses: ./.github/workflows/codeql-analysis.yml
+
+  matrix_build_upload:
+    permissions:
+      contents: write
+    # needs: [call_build_and_test, call_codeql_analysis]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ linux, windows, darwin ]
+        arch: [ 386, amd64, arm64 ]
+        exclude:
+          - os: linux
+            arch: arm64
+          - os: windows
+            arch: arm64
+          - os: darwin
+            arch: 386
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+        run: mkdir -p target; go build -o target -v -x ./...
+
+      - name: Create release archive (tar.gz)
+        if: ${{ matrix.os != 'windows' }}
+        run: tar -cvzf ${{ env.SERVICE_NAME }}.${{ matrix.os }}-${{ matrix.arch }}.tar.gz target/* README.md LICENSE install.sh run-*.sh
+
+      - name: Upload release archive (tar.gz)
+        if: ${{ matrix.os != 'windows' }}
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.SERVICE_NAME }}.${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          if-no-files-found: warn
+
+      - name: Create release archive (zip)
+        if: ${{ matrix.os == 'windows' }}
+        run: zip -v ${{ env.SERVICE_NAME }}.${{ matrix.os }}-${{ matrix.arch }}.zip target/* README.md LICENSE install.sh run-*.sh
+
+      - name: Upload release archive (zip)
+        if: ${{ matrix.os == 'windows' }}
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.SERVICE_NAME }}.${{ matrix.os }}-${{ matrix.arch }}.zip
+          if-no-files-found: warn
+
+  create_release:
+    permissions:
+      contents: write
+      pull-requests: read
+      issues: read
+    needs: matrix_build_upload
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Release Changelog Builder
+        uses: mikepenz/release-changelog-builder-action@v3.4.0
+        id: build_changelog
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          path: release-artifacts
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          prerelease: false
+          body: ${{ steps.build_changelog.outputs.changelog }}
+          files: ${{steps.download.outputs.download-path}}/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,18 +72,11 @@ jobs:
   create_release:
     permissions:
       contents: write
-      pull-requests: read
-      issues: read
     needs: matrix_build_upload
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - name: Release Changelog Builder
-        uses: mikepenz/release-changelog-builder-action@v3.4.0
-        id: build_changelog
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Download Release Artifacts
         uses: actions/download-artifact@v3
         id: download
@@ -94,5 +87,6 @@ jobs:
         with:
           draft: false
           prerelease: false
+          generate_release_notes: true
           body: ${{ steps.build_changelog.outputs.changelog }}
           files: ${{steps.download.outputs.download-path}}/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 env:
   GO_VERSION: 1.19

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ config.yaml
 test/contract/*/log/**
 attendee-service
 main
-
 api-generator
+target


### PR DESCRIPTION
Automatically build artifacts for Linux, Windows and macOS and upload them to a newly created release on tags matching the pattern `v*.*.*`.

Also updates the GitHub Actions used by all workflows to latest versions and once again uses the latest version of `pact-foundation/pact-ruby-standalone`.

### Open Tasks
- [ ] decide what should be included in each artifact archive and in which folder structure
- [ ] configure release note generator (currently `mikepenz/release-changelog-builder-action`) to generate proper release notes
- [ ] decide when and how releases should be triggered
- [ ] consider whether release-style builds including artifacts should also be run on any commit on `main` (e.g. after PRs), just without creating a release