### PR TITLE
Issue 172 api expansions

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -85,7 +85,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
-        - BearerAuth: []
+        - AnyAudienceBearerAuth: []
     post:
       tags:
         - registration
@@ -764,7 +764,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
-        - BearerAuth: []
+        - AnyAudienceBearerAuth: []
         - ApiKeyAuth: []
   /attendees/{id}/options/{option}:
     get:
@@ -826,7 +826,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
-        - BearerAuth: []
+        - AnyAudienceBearerAuth: []
         - ApiKeyAuth: []
   /attendees/{id}/packages/{package}:
     get:
@@ -886,7 +886,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
-        - BearerAuth: []
+        - AnyAudienceBearerAuth: []
         - ApiKeyAuth: []
   /attendees/{id}/payments-changed:
     post:
@@ -995,7 +995,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
-        - BearerAuth: []
+        - AnyAudienceBearerAuth: []
         - ApiKeyAuth: []
     post:
       tags:
@@ -1547,6 +1547,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
 components:
   schemas:
     Attendee:
@@ -2335,6 +2338,8 @@ components:
             - attendee.data.duplicate (duplicate registration - nickname + email + zip)
             - attendee.user.duplicate (this identity already has a registration, and it isn't deleted)
             - attendee.write.error (database error)
+            - attendee.param.invalid (invalid flag/option/package code used in request parameters)
+            - attendee.param.error (technical failure during flag/option/package visibility check)
             - attendee.payment.error (payment service failure while updating attendee)
             - attendee.id.notfound (no such badge number in the database)
             - attendee.id.invalid (syntactically invalid badge number, must be positive integer)
@@ -2378,6 +2383,10 @@ components:
               - email address does not match the regular expression
               - you need to refill the flux capacitor before the operation can succeed
   securitySchemes:
+    AnyAudienceBearerAuth:
+      type: http
+      scheme: bearer
+      description: An access token obtained from the identity provider directly, for any audience. Some endpoints intentionally leave out the audience check so other systems can query them if they have a valid user token for their audience.
     BearerAuth:
       type: http
       scheme: bearer

--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -702,6 +702,192 @@ paths:
       security:
         - BearerAuth: []
         - ApiKeyAuth: []
+  /attendees/{id}/flags/{flag}:
+    get:
+      tags:
+        - registration
+      summary: Obtain the current state of a flag
+      description: |-
+        Returns the current state of a flag for the given attendee, if your permissions and flag visibility allows.
+        
+        Flags are used to store yes/no-style information about an attendee, typically displayed as checkboxes.
+        
+        There are both admin-only and user level flags, depending on who can set them. Flag configuration
+        also determines who can see the value of a flag. Some admin-only flags such as "staff" may be available
+        to the user, others such as "skip_ban_check" may not be.
+      operationId: getFlagState
+      parameters:
+        - name: id
+          in: path
+          description: Badge number of attendee
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            format: int64
+        - name: flag
+          in: path
+          description: Code of the flag, as set in the service configuration
+          required: true
+          schema:
+            type: string
+            example: anon
+      responses:
+        '200':
+          description: successful operation. The response body will tell you whether the attendee has the flag or not.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChoiceState'
+        '400':
+          description: Invalid ID supplied, or invalid flag code supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Authorization required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: You do not have permission to see this attendee or flag.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Attendee not found. Note, if the attendee does not have the flag set, this endpoint will return status 200.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+  /attendees/{id}/options/{option}:
+    get:
+      tags:
+        - registration
+      summary: Obtain the current state of an option
+      description: |-
+        Returns the current state of an option for the given attendee, if your permissions and option visibility allows.
+        
+        Options are used to store yes/no-style choices an attendee makes that do not cost money, and displayed as checkboxes.
+        The difference to flags is that flags are things an admin may conceivably change, while options are personal choices
+        made by the attendee. Therefore, admin-only options are not a thing.
+      operationId: getOptionState
+      parameters:
+        - name: id
+          in: path
+          description: Badge number of attendee
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            format: int64
+        - name: option
+          in: path
+          description: Code of the option, as set in the service configuration
+          required: true
+          schema:
+            type: string
+            example: music
+      responses:
+        '200':
+          description: successful operation. The response body will tell you whether the attendee has the option or not.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChoiceState'
+        '400':
+          description: Invalid ID supplied, or invalid option code supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Authorization required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: You do not have permission to see this attendee or option.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Attendee not found. Note, if the attendee does not have the option set, this endpoint will return status 200.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+  /attendees/{id}/packages/{package}:
+    get:
+      tags:
+        - registration
+      summary: Obtain the current state of a package
+      description: |-
+        Returns the current state of a package for the given attendee, if your permissions and package visibility allows.
+        
+        Packages represent things that cost money.
+      operationId: getPackageState
+      parameters:
+        - name: id
+          in: path
+          description: Badge number of attendee
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            format: int64
+        - name: package
+          in: path
+          description: Code of the package, as set in the service configuration
+          required: true
+          schema:
+            type: string
+            example: artshow-table
+      responses:
+        '200':
+          description: successful operation. The response body will tell you whether the attendee has the package or not.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChoiceState'
+        '400':
+          description: Invalid ID supplied, or invalid package code supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Authorization required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: You do not have permission to see this attendee or package.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Attendee not found. Note, if the attendee does not have the package set, this endpoint will return status 200.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
   /attendees/{id}/payments-changed:
     post:
       tags:
@@ -1716,7 +1902,7 @@ components:
             - descending
     AttendeeSearchSingleCriterion:
       type: object
-      description: a set of search criteria. All criteria are optional, but if you set multiple ones, they are connected by AND.
+      description: a single set of search criteria. All criteria are optional, but if you set multiple ones, they are connected by AND.
       properties:
         ids:
           type: array
@@ -1744,6 +1930,20 @@ components:
           maxLength: 2
           description: 2 letter ISO-3166-1 country code for the address (Alpha-2 code), for example DE for Germany.
           example: DE
+        birthday_from:
+          type: string
+          format: date
+          description: find only attendees who were born no earlier than the provided date (inclusive, that is an attendee born on this exact day will match). ISO date (yyyy-mm-dd).
+          minLength: 10
+          maxLength: 10
+          example: 1983-10-24
+        birthday_to:
+          type: string
+          format: date
+          description: find only attendees who were born no later than the provided date (inclusive, that is an attendee born on this exact day will match). ISO date (yyyy-mm-dd).
+          minLength: 10
+          maxLength: 10
+          example: 2003-10-24
         email:
           type: string
           description: full match on email, case insensitive, use * as a wildcard for substring matches
@@ -1831,6 +2031,14 @@ components:
       maximum: 1
       description: desired state of choice, 0 = must be no, 1 = must be yes. Leave missing to pose no condition.
       example: 1
+    ChoiceState:
+      type: object
+      required:
+        - present
+      properties:
+        present:
+          type: boolean
+          description: Whether the attendee has this flag enabled or not.
     AttendeeFieldSelection:
       type: array
       description: |-

--- a/docs/config-template.yaml
+++ b/docs/config-template.yaml
@@ -77,9 +77,11 @@ choices:
       description: 'Legal Name is Confidential'
     digi-book:
       description: 'Digital only convention booklet'
+      visible_for: regdesk
     ev:
       description: 'Eurofurence e.V. Member'
       admin_only: true
+      visible_for: regdesk
     terms-accepted:
       description: 'Accepted the terms'
       default: true
@@ -87,15 +89,18 @@ choices:
     guest:
       description: 'Guest of the Convention'
       admin_only: true
+      visible_for: self,regdesk,sponsordesk
     skip_ban_check:
       description: 'Bypass ban check for this attendee'
       admin_only: true
     staff:
       description: 'Staff'
       admin_only: true
+      visible_for: self,regdesk,sponsordesk
     director:
       description: 'Director'
       admin_only: true
+      visible_for: self,regdesk,sponsordesk
   packages:
     room-none:
       description: 'No Room'
@@ -108,27 +113,32 @@ choices:
       vat_percent: 19
       default: true
       at-least-one-mandatory: true
+      visible_for: regdesk
     stage:
       description: 'Entrance Fee (Stage Ticket)'
       price: 500
       vat_percent: 19
       default: true
+      visible_for: regdesk
     sponsor:
       description: 'Sponsor Upgrade'
       price: 8000
       vat_percent: 19
+      visible_for: regdesk,sponsordesk
     sponsor2:
       description: 'Supersponsor Upgrade'
       price: 19000
       vat_percent: 19
       constraint: '!sponsor'
       constraint_msg: 'Please choose only one of Sponsor or Supersponsor.'
+      visible_for: regdesk,sponsordesk
     tshirt:
       description: 'Paid T-Shirt (non-sponsor)'
       price: 2000
       vat_percent: 19
       constraint: '!sponsor,!sponsor2'
       constraint_msg: 'Sponsors and supersponsors get their T-Shirt for free.'
+      visible_for: sponsordesk
     day-sun:
       description: 'Day Guest (Sunday)'
       price: 7000
@@ -136,6 +146,7 @@ choices:
       at-least-one-mandatory: true
       constraint: '!attendance,!stage'
       constraint_msg: 'Must disable Convention Ticket and Stage Ticket for Day Guests.'
+      visible_for: regdesk
     day-mon:
       description: 'Day Guest (Monday)'
       price: 7000
@@ -143,6 +154,7 @@ choices:
       at-least-one-mandatory: true
       constraint: '!attendance,!stage'
       constraint_msg: 'Must disable Convention Ticket and Stage Ticket for Day Guests.'
+      visible_for: regdesk
     day-tue:
       description: 'Day Guest (Tuesday)'
       price: 7000
@@ -150,6 +162,7 @@ choices:
       at-least-one-mandatory: true
       constraint: '!attendance,!stage'
       constraint_msg: 'Must disable Convention Ticket and Stage Ticket for Day Guests.'
+      visible_for: regdesk
     day-wed:
       description: 'Day Guest (Wednesday)'
       price: 7000
@@ -157,6 +170,7 @@ choices:
       at-least-one-mandatory: true
       constraint: '!attendance,!stage'
       constraint_msg: 'Must disable Convention Ticket and Stage Ticket for Day Guests.'
+      visible_for: regdesk
     dealer-half:
       description: 'Dealer Table Fee (Half)'
       price: 5000

--- a/internal/api/v1/attendee/api.go
+++ b/internal/api/v1/attendee/api.go
@@ -69,6 +69,8 @@ type AttendeeSearchSingleCriterion struct {
 	Name                 string          `json:"name"`
 	Address              string          `json:"address"`
 	Country              string          `json:"country"`
+	BirthdayFrom         string          `json:"birthday_from"`
+	BirthdayTo           string          `json:"birthday_to"`
 	Email                string          `json:"email"`
 	Telegram             string          `json:"telegram"`
 	SpokenLanguages      map[string]int8 `json:"spoken_languages"`

--- a/internal/api/v1/attendee/api.go
+++ b/internal/api/v1/attendee/api.go
@@ -124,3 +124,9 @@ type AttendeeSearchResult struct {
 	Registered           *string        `json:"registered,omitempty"`
 	AdminComments        *string        `json:"admin_comments,omitempty"`
 }
+
+// --- flags/options/packages result ---
+
+type ChoiceState struct {
+	Present bool `json:"present"`
+}

--- a/internal/repository/config/structure.go
+++ b/internal/repository/config/structure.go
@@ -124,6 +124,7 @@ type (
 		Default       bool    `yaml:"default"`                // if set to true, is added to flags by default. Not available for admin only flags!
 		AdminOnly     bool    `yaml:"admin_only"`             // this flag is kept under the adminInfo structure, so it is not visible to users
 		ReadOnly      bool    `yaml:"read_only"`              // this flag is kept under the normal flags, thus visible to end user, but only admin can change it
+		VisibleFor    string  `yaml:"visible_for"`            // comma separated list of permissions which allow seeing the flag/option/package. Admin can always see everything, "self" can always see non-admin_only, but you can add it for admin_only fields. This field also controls who else can see the info based on their permissions admin field. Example: "self,sponsordesk"
 		Mandatory     bool    `yaml:"at-least-one-mandatory"` // one of these MUST be chosen (no constraint if not set on any choices)
 		Constraint    string  `yaml:"constraint"`
 		ConstraintMsg string  `yaml:"constraint_msg"`

--- a/internal/repository/database/inmemorydb/match.go
+++ b/internal/repository/database/inmemorydb/match.go
@@ -45,7 +45,8 @@ func (r *InMemoryRepository) matches(cond *attendee.AttendeeSearchSingleCriterio
 		choiceMatch(cond.Permissions, adm.Permissions) &&
 		matchesSubstringGlobOrEmpty(cond.AdminComments, adm.AdminComments) &&
 		matchesAddInfoPresence(cond.AddInfo, addInf) &&
-		matchesOverdue(cond.AddInfo, a.CacheDueDate, r.Now().Format(config.IsoDateFormat), st.Status)
+		matchesOverdue(cond.AddInfo, a.CacheDueDate, r.Now().Format(config.IsoDateFormat), st.Status) &&
+		matchesIsoDateRange(cond.BirthdayFrom, cond.BirthdayTo, a.Birthday)
 }
 
 func matchesUintSliceOrEmpty(cond []uint, value uint) bool {
@@ -132,4 +133,18 @@ func matchesOverdue(addInfoConds map[string]int8, dueDate string, currDate strin
 	} else {
 		return false
 	}
+}
+
+func matchesIsoDateRange(condFrom string, condTo string, value string) bool {
+	if value != "" && condFrom != "" {
+		if value < condFrom {
+			return false
+		}
+	}
+	if value != "" && condTo != "" {
+		if value > condTo {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/repository/database/inmemorydb/match_test.go
+++ b/internal/repository/database/inmemorydb/match_test.go
@@ -1,0 +1,17 @@
+package inmemorydb
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMatchesIsoDateRange(t *testing.T) {
+	require.True(t, matchesIsoDateRange("", "", ""))
+	require.True(t, matchesIsoDateRange("", "", "1972-10-24"))
+	require.True(t, matchesIsoDateRange("1976-10-22", "1977-01-01", ""))
+	require.True(t, matchesIsoDateRange("1976-10-22", "1977-01-01", "1976-12-24"))
+	require.True(t, matchesIsoDateRange("1976-10-22", "1977-01-01", "1976-10-22")) // left inclusive
+	require.True(t, matchesIsoDateRange("1976-10-22", "1977-01-01", "1977-01-01")) // right inclusive
+	require.False(t, matchesIsoDateRange("1976-10-22", "1977-01-01", "1972-12-24"))
+	require.False(t, matchesIsoDateRange("1976-10-22", "1977-01-01", "1979-12-24"))
+}

--- a/internal/repository/database/mysqldb/searchquery.go
+++ b/internal/repository/database/mysqldb/searchquery.go
@@ -255,6 +255,12 @@ func (r *MysqlRepository) addSingleCondition(cond *attendee.AttendeeSearchSingle
 	if len(cond.AddInfo) > 0 {
 		query.WriteString(r.addInfoConditions(cond.AddInfo, params, paramBaseName, &paramNo))
 	}
+	if cond.BirthdayFrom != "" {
+		query.WriteString(stringGreaterThanOrEqual("a.birthday", cond.BirthdayFrom, params, paramBaseName, &paramNo))
+	}
+	if cond.BirthdayTo != "" {
+		query.WriteString(stringLessThanOrEqual("a.birthday", cond.BirthdayTo, params, paramBaseName, &paramNo))
+	}
 
 	return query.String()
 }
@@ -326,6 +332,20 @@ func stringExact(field string, condition string, params map[string]interface{}, 
 	params[pName] = condition
 	*idx++
 	return fmt.Sprintf("    AND ( LOWER(%s) = LOWER( @%s ) )\n", field, pName)
+}
+
+func stringLessThanOrEqual(field string, condition string, params map[string]interface{}, paramBaseName string, idx *int) string {
+	pName := fmt.Sprintf("%s_%d", paramBaseName, *idx)
+	params[pName] = condition
+	*idx++
+	return fmt.Sprintf("    AND ( STRCMP(%s,@%s) <= 0 )\n", field, pName)
+}
+
+func stringGreaterThanOrEqual(field string, condition string, params map[string]interface{}, paramBaseName string, idx *int) string {
+	pName := fmt.Sprintf("%s_%d", paramBaseName, *idx)
+	params[pName] = condition
+	*idx++
+	return fmt.Sprintf("    AND ( STRCMP(%s,@%s) >= 0 )\n", field, pName)
 }
 
 func choiceMatch(field string, condition map[string]int8, params map[string]interface{}, paramBaseName string, idx *int) string {

--- a/internal/repository/database/mysqldb/searchquery_test.go
+++ b/internal/repository/database/mysqldb/searchquery_test.go
@@ -110,6 +110,8 @@ func TestTwoFullSearchQueries(t *testing.T) {
 					"overdue":       1,
 					"sponsor-items": 1,
 				},
+				BirthdayFrom: "1970-10-24",
+				BirthdayTo:   "1980-12-24",
 			},
 		},
 		MinId:      1,
@@ -153,6 +155,7 @@ func TestTwoFullSearchQueries(t *testing.T) {
 		"param_1_18_2":                      "sponsor-items",
 		"param_2_1":                         "small%bird",
 		"param_2_2":                         "Johnny",
+		"param_2_20":                        "1980-12-24",
 		"param_2_3":                         "%Berlin%",
 		"param_2_4":                         "CH",
 		"param_2_5":                         "%gg@hh%",
@@ -170,6 +173,7 @@ func TestTwoFullSearchQueries(t *testing.T) {
 		"param_2_17":                        "%more user comments%",
 		"param_2_18_1":                      "2020-12-23",
 		"param_2_18_2":                      "sponsor-items",
+		"param_2_19":                        "1970-10-24",
 	}
 	expectedQuery := `SELECT IFNULL(ad.flags, '') as admin_flags, IFNULL(st.status, 'new') as status, a.cache_due_date as cache_due_date, a.cache_open_balance as cache_open_balance, a.cache_payment_balance as cache_payment_balance, a.cache_total_dues as cache_total_dues, a.flags as flags, a.id as id, a.options as options, a.packages as packages, a.pronouns as pronouns, a.registration_language as registration_language 
 FROM att_attendees AS a 
@@ -228,6 +232,8 @@ WHERE (
     AND ( STRCMP( IFNULL(a.cache_due_date,'9999-99-99'), @param_2_18_1 ) < 0 )
     AND ( IFNULL(st.status, 'new') IN ('approved','partially paid') )
     AND ( ( SELECT COUNT(*) FROM att_additional_infos WHERE attendee_id = a.id AND area = @param_2_18_2 ) > 0 )
+    AND ( STRCMP(a.birthday,@param_2_19) >= 0 )
+    AND ( STRCMP(a.birthday,@param_2_20) <= 0 )
   )
 ) AND a.id >= @param_0_1 AND a.id <= @param_0_2 ORDER BY CONCAT(a.first_name, ' ', a.last_name) DESC`
 

--- a/internal/web/controller/attendeectl/mapping.go
+++ b/internal/web/controller/attendeectl/mapping.go
@@ -83,3 +83,13 @@ func addWrappingCommas(v string) string {
 	}
 	return v
 }
+
+func commaSeparatedContains(commaSeparated string, singleValue string) bool {
+	list := strings.Split(removeWrappingCommas(commaSeparated), ",")
+	for _, e := range list {
+		if e == singleValue {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/web/middleware/security.go
+++ b/internal/web/middleware/security.go
@@ -179,6 +179,10 @@ func allowPrefixSuffix(actualMethod string, actualUrlPath string, allowedMethod 
 	return actualMethod == allowedMethod && strings.HasPrefix(actualUrlPath, allowedPrefix) && strings.HasSuffix(actualUrlPath, allowedSuffix)
 }
 
+func allowPrefixContains(actualMethod string, actualUrlPath string, allowedMethod string, allowedPrefix string, mustContain string) bool {
+	return actualMethod == allowedMethod && strings.HasPrefix(actualUrlPath, allowedPrefix) && strings.Contains(actualUrlPath, mustContain)
+}
+
 func canSkipAccessTokenCheckWithCookieAuth(method string, urlPath string) bool {
 	// positive list for request URLs and Methods where the access token check may be skipped
 	// (performance critical + cannot be used for data extraction only!)
@@ -192,7 +196,10 @@ func canSkipAudienceCheckWithAccessToken(method string, urlPath string) bool {
 	// meaning the identity provider signed them for another client, such as the dealer system.
 	// (should not be set for endpoints that allow extraction of personal data!)
 	return allow(method, urlPath, http.MethodGet, "/api/rest/v1/attendees") || // list my badge numbers
-		allowPrefixSuffix(method, urlPath, http.MethodGet, "/api/rest/v1/attendees/", "/status") // current status value only
+		allowPrefixSuffix(method, urlPath, http.MethodGet, "/api/rest/v1/attendees/", "/status") || // current status value only
+		allowPrefixContains(method, urlPath, http.MethodGet, "/api/rest/v1/attendees/", "/flags/") || // yes/no only
+		allowPrefixContains(method, urlPath, http.MethodGet, "/api/rest/v1/attendees/", "/options/") || // yes/no only
+		allowPrefixContains(method, urlPath, http.MethodGet, "/api/rest/v1/attendees/", "/packages/") // yes/no only
 }
 
 // --- top level ---

--- a/test/acceptance/requirehelpers_test.go
+++ b/test/acceptance/requirehelpers_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 )
 
+func tstRequireSuccessResponse(t *testing.T, response tstWebResponse, expectedStatus int, resultBodyPtr interface{}) {
+	require.Equal(t, expectedStatus, response.status, "unexpected http response status")
+	tstParseJson(response.body, resultBodyPtr)
+}
+
 func tstRequireErrorResponse(t *testing.T, response tstWebResponse, expectedStatus int, expectedMessage string, expectedDetails interface{}) {
 	require.Equal(t, expectedStatus, response.status, "unexpected http response status")
 	errorDto := errorapi.ErrorDto{}

--- a/test/testconfig-base.yaml
+++ b/test/testconfig-base.yaml
@@ -42,9 +42,11 @@ choices:
       description: 'Wheelchair'
     anon:
       description: 'Legal Name is Confidential'
+      visible_for: regdesk
     ev:
       description: 'Eurofurence e.V. Member'
       read_only: true
+      visible_for: regdesk
     terms-accepted:
       description: 'Accepted the terms'
       default: true
@@ -52,6 +54,7 @@ choices:
     guest:
       description: 'Guest of the Convention'
       admin_only: true
+      visible_for: self,sponsordesk,regdesk
     skip_ban_check:
       description: 'Bypass ban check for this attendee'
       admin_only: true
@@ -80,16 +83,19 @@ choices:
       description: 'Sponsor Upgrade'
       price: 6500
       vat_percent: 19
+      visible_for: sponsordesk
     sponsor2:
       description: 'Supersponsor Upgrade'
       price: 16000
       vat_percent: 19
       constraint: '!sponsor'
       constraint_msg: 'Please choose only one of Sponsor or Supersponsor.'
+      visible_for: sponsordesk
     boat-trip:
       description: 'Boat Trip'
       price: 2000
       vat_percent: 19
+      visible_for: regdesk
     mountain-trip:
       description: 'Mountain Trip'
       price: 3000
@@ -121,10 +127,12 @@ choices:
   options:
     art:
       description: 'Artist'
+      visible_for: sponsordesk
     anim:
       description: 'Animator'
     music:
       description: 'Musician'
+      visible_for: sponsordesk
     suit:
       description: 'Fursuiter'
 tshirtsizes:


### PR DESCRIPTION
- closes #172 

This PR adds two new features to the API:
- search criteria now include birthday_from and birthday_to (for use by onsite regdesk)
- separate GET endpoints for flags, packages, options with expanded visibility configuration. These endpoints permit tokens with a different audience (for use by 3rd party systems). This also gives limited readability for admin-only flags such as "guest", "staff", "director", if configured on the flag.