### PR TITLE
feat: prevent information leakage for non-admins

### DIFF
--- a/internal/web/controller/statusctl/statusctl.go
+++ b/internal/web/controller/statusctl/statusctl.go
@@ -41,8 +41,17 @@ func Create(server chi.Router, attendeeSrv attendeesrv.AttendeeService) {
 func getStatusHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	att, err := attendeeByIdMustReturnOnError(ctx, w, r)
+	id, err := ctlutil.AttendeeIdFromVars(ctx, w, r)
 	if err != nil {
+		return
+	}
+	att, err := attendeeService.GetAttendee(ctx, id)
+	if err != nil {
+		if filter.IsGroupOrApiTokenCond(r, config.OidcAdminGroup()) {
+			ctlutil.AttendeeNotFoundErrorHandler(ctx, w, r, id)
+		} else {
+			ctlutil.UnauthorizedError(ctx, w, r, "you are not authorized to access this data - the attempt has been logged", "non-admin attendee not found or not authorized")
+		}
 		return
 	}
 


### PR DESCRIPTION
Fenrikur asked me about error code behavior of /attendees/{id}/status in case of people without regs (for edge cases within the app). I noticed some information leakage, which allowed someone to check which reg IDs exist. Since we have the nosecount, people can already guess what numbers exist - but for good practice, the error code should not leak the existence of non-existence of reg IDs